### PR TITLE
Implemented button to toggle the right panel.

### DIFF
--- a/files/compareImages.js
+++ b/files/compareImages.js
@@ -19,6 +19,7 @@ var play = true;
 var displayDetails = true;
 var displayExif = true;
 var displayPixelated = true;
+var displayRightPanel = false;
 
 var temp;
 
@@ -60,6 +61,20 @@ var temp;
 			jQuery('#content').attr('style', '');
 		}
 	});
+
+	// Right panel button listener
+	displayRightPanel = jQuery('#rightPanel').is(':checked');
+	jQuery('#rightPanel').parent().bind('click', function () {
+		displayRightPanel = this.childNodes[0].checked;
+
+		// Trigger functions to display right based on state.
+		displayRight(displayRightPanel);
+		if (displayRightPanel) {
+			// Rerun compareImages to correct zoom behavior when hiding the right panel.
+			compareImages();
+		}
+	});
+
 
 	// Play/Pause button listener
 	jQuery('#play').bind('click', function () {

--- a/files/compareImages.js
+++ b/files/compareImages.js
@@ -69,6 +69,7 @@ var temp;
 
 		// Trigger functions to display right based on state.
 		displayRight(displayRightPanel);
+		jQuery('#rightPanel').prop('checked', displayRightPanel);
 		if (displayRightPanel) {
 			// Rerun compareImages to correct zoom behavior when hiding the right panel.
 			compareImages();

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 	<label><input id="displayDetails" type="checkbox" checked="">Display details</label>
 	<label><input id="displayExif" type="checkbox" checked="">Display EXIF</label>
 	<label><input id="pixelated" type="checkbox" checked="">Pixelated</label>
-	<label><input id="rightPanel" type="checkbox">Display right panel</label>
+	<label><input id="rightPanel" type="checkbox" checked="">Display right panel</label>
 	<button id="stack">Hold to swap</button>
 	<button id="play">Play/Pause</button>
 	<a id="github" href="https://github.com/jklgit/Image-Comparison-in-Browser">View on Github</a>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 	<label><input id="displayDetails" type="checkbox" checked="">Display details</label>
 	<label><input id="displayExif" type="checkbox" checked="">Display EXIF</label>
 	<label><input id="pixelated" type="checkbox" checked="">Pixelated</label>
+	<label><input id="rightPanel" type="checkbox">Display right panel</label>
 	<button id="stack">Hold to swap</button>
 	<button id="play">Play/Pause</button>
 	<a id="github" href="https://github.com/jklgit/Image-Comparison-in-Browser">View on Github</a>


### PR DESCRIPTION
This is an attempt to implement https://github.com/jklgit/Image-Comparison-in-Browser/issues/6

This pull request adds a checkbox to allow the user to show/hide the right panel, allowing for a 50-50 view of the image comparison view.